### PR TITLE
修改设备唯一标识和指示灯初始化

### DIFF
--- a/app/pando/gateway/pando_device_register.c
+++ b/app/pando/gateway/pando_device_register.c
@@ -137,9 +137,11 @@ pando_device_register(register_callback callback)
     str_device_key = pando_data_get(DATANAME_DEVICE_KEY);
 
     char str_device_serial[DEVICE_SERIAL_BUF_LEN];
-    uint32 device_serial = system_get_chip_id();
-    os_sprintf(str_device_serial, "%08x", device_serial);
-
+    char device_sta_mac[6];
+    wifi_get_macaddr(STATION_IF,device_sta_mac);
+    os_sprintf(str_device_serial, "%02x%02x%02x%02x%02x%02x", device_sta_mac[0], device_sta_mac[1], device_sta_mac[2], device_sta_mac[3] \
+    		, device_sta_mac[4], device_sta_mac[5]);
+    PRINTF("device_serial:%s\n", str_device_serial);
     // try register device via HTTP
     struct jsontree_string json_product_key = JSONTREE_STRING(PANDO_PRODUCT_KEY);
     struct jsontree_string json_device_code = JSONTREE_STRING(str_device_serial);

--- a/app/user/device_config.h
+++ b/app/user/device_config.h
@@ -12,7 +12,7 @@
 #ifndef __DEVICE_CONFIG_H__
 #define __DEVICE_CONFIG_H__
 
-#define PANDO_PRODUCT_KEY "e8ba22c385dcebfae78aa1b2686c97f081d0c364501ff62975f034a2b810fea0"
+#define PANDO_PRODUCT_KEY "18376b6dc8d2aae98dcdb3273e1641a802988cd74ea5f3bfff2e09a75e3f2493"
 
 #endif
 

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -38,9 +38,7 @@ void user_init(void)
 	//long press gpio4, enter into wifi config mode.
 	peri_single_key_init(4, user_key_long_press_cb, NULL);
 
-	// gpio5 drive the led, which indicate the wifi config mode.
-	peri_led_init(5);
-
+	// add you object init here.
 	led_object_init();
 
 	pando_framework_init();

--- a/app/user/wifi_config.c
+++ b/app/user/wifi_config.c
@@ -98,7 +98,11 @@ void ICACHE_FLASH_ATTR
 wifi_config(wifi_config_callback config_cb)
 {
 	PRINTF("wifi config start...\n");
+
+	// gpio5 drive the led, which indicate the wifi config mode.
+	peri_led_init(5);
 	peri_led_blink(BLINK_QUICK);
+
 	wifi_config_cb = config_cb;
     if(s_config_start_flag)
     {


### PR DESCRIPTION
1、设备唯一标识由芯片ID改为sta mac地址。
2、指示灯初始化放在wifi配置中。
